### PR TITLE
Ability to use regex in ignoreFiles

### DIFF
--- a/src/files-handler.ts
+++ b/src/files-handler.ts
@@ -14,7 +14,7 @@ export class FilesHandler {
 		private lh: LinksHandler,
 		private consoleLogPrefix: string = "",
 		private ignoreFolders: string[] = [],
-		private ignoreFiles: string[] = [],
+		private ignoreFilesRegex: RegExp[] = [],
 	) { }
 
 	isPathIgnored(path: string): boolean {
@@ -27,8 +27,7 @@ export class FilesHandler {
 			}
 		}
 
-		for (let file of this.ignoreFiles) {
-			let fileRegex = new RegExp(file)
+		for (let fileRegex of this.ignoreFilesRegex) {
 			let testResult = fileRegex.test(path)
 			// console.log(path,fileRegex,testResult)
 			if(testResult) {

--- a/src/files-handler.ts
+++ b/src/files-handler.ts
@@ -28,9 +28,12 @@ export class FilesHandler {
 		}
 
 		for (let file of this.ignoreFiles) {
-			if (path == file) {
-				return true;
-			}
+			let fileRegex = new RegExp(file)
+            let testResult = fileRegex.test(path)
+            // console.log(path,fileRegex,testResult)
+            if(testResult) {
+                return true;
+            }
 		}
 	}
 

--- a/src/files-handler.ts
+++ b/src/files-handler.ts
@@ -29,11 +29,11 @@ export class FilesHandler {
 
 		for (let file of this.ignoreFiles) {
 			let fileRegex = new RegExp(file)
-            let testResult = fileRegex.test(path)
-            // console.log(path,fileRegex,testResult)
-            if(testResult) {
-                return true;
-            }
+			let testResult = fileRegex.test(path)
+			// console.log(path,fileRegex,testResult)
+			if(testResult) {
+				return true;
+			}
 		}
 	}
 

--- a/src/links-handler.ts
+++ b/src/links-handler.ts
@@ -63,7 +63,7 @@ export class LinksHandler {
 		private app: App,
 		private consoleLogPrefix: string = "",
 		private ignoreFolders: string[] = [],
-		private ignoreFiles: string[] = [],
+		private ignoreFilesRegex: RegExp[] = [],
 	) { }
 
 	isPathIgnored(path: string): boolean {
@@ -76,9 +76,8 @@ export class LinksHandler {
 			}
 		}
 
-		for (let file of this.ignoreFiles) {
-			let regexFile = new RegExp(file)
-			if (regexFile.test(path)) {
+		for (let fileRegex of this.ignoreFilesRegex) {
+			if (fileRegex.test(path)) {
 				return true;
 			}
 		}

--- a/src/links-handler.ts
+++ b/src/links-handler.ts
@@ -77,7 +77,8 @@ export class LinksHandler {
 		}
 
 		for (let file of this.ignoreFiles) {
-			if (path == file) {
+			let regexFile = new RegExp(file)
+			if (regexFile.test(file)) {
 				return true;
 			}
 		}

--- a/src/links-handler.ts
+++ b/src/links-handler.ts
@@ -78,7 +78,7 @@ export class LinksHandler {
 
 		for (let file of this.ignoreFiles) {
 			let regexFile = new RegExp(file)
-			if (regexFile.test(file)) {
+			if (regexFile.test(path)) {
 				return true;
 			}
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,11 +79,14 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 			callback: () => this.checkConsistent()
 		});
 
+		// make regex from given strings 
+		this.settings.ignoreFilesRegex = this.settings.ignoreFiles.map(val=>RegExp(val))
+
 		this.lh = new LinksHandler(
 			this.app,
 			"Consistent attachments and links: ",
 			this.settings.ignoreFolders,
-			this.settings.ignoreFiles
+			this.settings.ignoreFilesRegex
 		);
 
 		this.fh = new FilesHandler(
@@ -91,7 +94,7 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 			this.lh,
 			"Consistent attachments and links: ",
 			this.settings.ignoreFolders,
-			this.settings.ignoreFiles
+			this.settings.ignoreFilesRegex
 		);
 	}
 
@@ -105,8 +108,8 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 			}
 		}
 
-		for (let file of this.settings.ignoreFiles) {
-			if (path == file) {
+		for (let fileRegex of this.settings.ignoreFilesRegex) {
+			if (fileRegex.test(path)) {
 				return true;
 			}
 		}
@@ -500,7 +503,7 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 			this.app,
 			"Consistent attachments and links: ",
 			this.settings.ignoreFolders,
-			this.settings.ignoreFiles
+			this.settings.ignoreFilesRegex
 		);
 
 		this.fh = new FilesHandler(
@@ -508,7 +511,7 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 			this.lh,
 			"Consistent attachments and links: ",
 			this.settings.ignoreFolders,
-			this.settings.ignoreFiles
+			this.settings.ignoreFilesRegex,
 		);
 	}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@ export interface PluginSettings {
     changeNoteBacklinksAlt: boolean;
     ignoreFolders: string[];
     ignoreFiles: string[];
+    ignoreFilesRegex: RegExp[];
     attachmentsSubfolder: string;
     consistentReportFile: string;
     useBuiltInObsidianLinkCaching: boolean;
@@ -23,7 +24,8 @@ export const DEFAULT_SETTINGS: PluginSettings = {
     deleteExistFilesWhenMoveNote: true,
     changeNoteBacklinksAlt: false,
     ignoreFolders: [".git/", ".obsidian/"],
-    ignoreFiles: ["consistant\-report\.md"],
+    ignoreFiles: ["consistant\\-report\\.md"],
+    ignoreFilesRegex: [/consistant\-report\.md/],
     attachmentsSubfolder: "",
     consistentReportFile: "consistant-report.md",
     useBuiltInObsidianLinkCaching: false,
@@ -124,8 +126,9 @@ export class SettingTab extends PluginSettingTab {
                 .setPlaceholder("Example: consistant-report.md")
                 .setValue(this.plugin.settings.ignoreFiles.join("\n"))
                 .onChange((value) => {
-                    let paths = value.trim().split("\n")
+                    let paths = value.trim().split("\n");
                     this.plugin.settings.ignoreFiles = paths;
+                    this.plugin.settings.ignoreFilesRegex = paths.map(file => RegExp(file));
                     this.plugin.saveSettings();
                 }));
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,7 +23,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
     deleteExistFilesWhenMoveNote: true,
     changeNoteBacklinksAlt: false,
     ignoreFolders: [".git/", ".obsidian/"],
-    ignoreFiles: ["consistant-report.md"],
+    ignoreFiles: ["consistant\-report\.md"],
     attachmentsSubfolder: "",
     consistentReportFile: "consistant-report.md",
     useBuiltInObsidianLinkCaching: false,
@@ -124,7 +124,7 @@ export class SettingTab extends PluginSettingTab {
                 .setPlaceholder("Example: consistant-report.md")
                 .setValue(this.plugin.settings.ignoreFiles.join("\n"))
                 .onChange((value) => {
-                    let paths = value.trim().split("\n").map(value => this.getNormalizedPath(value));
+                    let paths = value.trim().split("\n")
                     this.plugin.settings.ignoreFiles = paths;
                     this.plugin.saveSettings();
                 }));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ export class Utils {
 
 
 	static normalizePathForFile(path: string): string {
-		// path = path.replace(/\\/gi, "/"); //replace \ to /
+		path = path.replace(/\\/gi, "/"); //replace \ to /
 		path = path.replace(/%20/gi, " "); //replace %20 to space
 		return path;
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ export class Utils {
 
 
 	static normalizePathForFile(path: string): string {
-		path = path.replace(/\\/gi, "/"); //replace \ to /
+		// path = path.replace(/\\/gi, "/"); //replace \ to /
 		path = path.replace(/%20/gi, " "); //replace %20 to space
 		return path;
 	}


### PR DESCRIPTION
Instead of passing absolute names, we pass regex. 

Why we need this? 
Ans: Consider excalidraw, if we use this (consistent links) plugin it produces issues in **consistent-report** file, at present excalidraw cant use regular markdown links in obsidian, so we want to ignore it.

This also Resolves Issue : #10  

**normalizePath** functions are converting regex escapes, so modified.

### New Usage
consistant\\-report\\.md -> ignores consistant-report.md
.*\\.excalidraw\\.md -> ignores all files ending with \*.excalidraw.md