### PR TITLE
Remove part after # when resolve file

### DIFF
--- a/src/links-handler.ts
+++ b/src/links-handler.ts
@@ -115,6 +115,7 @@ export class LinksHandler {
 
 
 	getFileByLink(link: string, owningNotePath: string): TFile {
+		link = link.replace(/#.+/, '');
 		return this.app.metadataCache.getFirstLinkpathDest(link, owningNotePath);
 	}
 


### PR DESCRIPTION
PR #40 was missing the part to resolve paths with `#`, which resulted in false `Bad links` results